### PR TITLE
Batter Backup Buff

### DIFF
--- a/src/main/java/pilot/cards/pilot/BatteryBackUp.java
+++ b/src/main/java/pilot/cards/pilot/BatteryBackUp.java
@@ -6,6 +6,7 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import pilot.PilotMod;
 import pilot.cards.CustomPilotModCard;
 import pilot.characters.Pilot;
+import pilot.actions.ExhumeArmamentAction;
 
 public class BatteryBackUp extends CustomPilotModCard {
     public static final String ID = PilotMod.makeID(BatteryBackUp.class);
@@ -17,11 +18,13 @@ public class BatteryBackUp extends CustomPilotModCard {
 
     private static final int COST = 1;
     private static final int SHIELDS = 5;
+    private static final int CARDS_RETURNED = 1;
     private static final int UPGRADE_PLUS_SHIELDS = 3;
 
     public BatteryBackUp() {
         super(ID, COST, TYPE, COLOR, RARITY, TARGET);
         magicNumber = baseMagicNumber = SHIELDS;
+        metaMagicNumber = baseMetaMagicNumber = CARDS_RETURNED;
         this.exhaust = true;
     }
 
@@ -34,6 +37,8 @@ public class BatteryBackUp extends CustomPilotModCard {
     public void use(AbstractPlayer p, AbstractMonster m) {
         if (((Pilot)p).hasTitan()) {
             ((Pilot) p).getTitan().increaseShields(magicNumber);
+            addToBot(new ExhumeArmamentAction(false));
+
         }
     }
 

--- a/src/main/resources/pilotResources/localization/eng/PilotMod-Card-Strings.json
+++ b/src/main/resources/pilotResources/localization/eng/PilotMod-Card-Strings.json
@@ -71,7 +71,7 @@
   },
   "pilot:BatteryBackUp": {
     "NAME": "Battery Back-up",
-    "DESCRIPTION": "Give your Titan !M! pilot:Shields. NL Exhaust.",
+    "DESCRIPTION": "Give your Titan !M! pilot:Shields. NL Shuffle !M! pilot:Armaments from your exhaust pile into your Titan. NL Exhaust.",
     "UPGRADE_DESCRIPTION": "Retain. NL Give your Titan !M! pilot:Shields. NL Shuffle !M! pilot:Armaments from your exhaust pile into your Titan. Exhaust."
   },
   "pilot:WallHang": {

--- a/src/main/resources/pilotResources/localization/eng/PilotMod-Card-Strings.json
+++ b/src/main/resources/pilotResources/localization/eng/PilotMod-Card-Strings.json
@@ -72,7 +72,7 @@
   "pilot:BatteryBackUp": {
     "NAME": "Battery Back-up",
     "DESCRIPTION": "Give your Titan !M! pilot:Shields. NL Exhaust.",
-    "UPGRADE_DESCRIPTION": "Retain. NL Give your Titan !M! pilot:Shields. NL Exhaust."
+    "UPGRADE_DESCRIPTION": "Retain. NL Give your Titan !M! pilot:Shields. NL Shuffle !M! pilot:Armaments from your exhaust pile into your Titan. Exhaust."
   },
   "pilot:WallHang": {
     "NAME": "Wall Hang",


### PR DESCRIPTION
I want batterybackup to be a bit stronger of a support card for your Titan. Allowing it to return an exhuasted titan card should give it that little boost it needs, as well as giving the player a good reason to upgrade it. Retaining the is much stronger if you have yet to play the titan card you'd like to return.

